### PR TITLE
Show match URL in confirmation prompt

### DIFF
--- a/beetsplug/rymgenre/__init__.py
+++ b/beetsplug/rymgenre/__init__.py
@@ -137,7 +137,7 @@ class RymGenrePlugin(BeetsPlugin):
             url = ui.input_('Enter rateyourmusic url:')
             return { 'href': url }
 
-        print(u'Genre for album:\n    {0} - {1}'.format(
+        print(u'Fetching genre for album:\n    {0} - {1}'.format(
             beets_album.albumartist, beets_album.album))
 
         print(u'URL:\n    %s' % albums[0]['href'])


### PR DESCRIPTION
An output example:

```
Genre for album:
    3 Doors Down - Away From the Sun
URL:
    http://rateyourmusic.com/release/album/3_doors_down/away_from_the_sun/
3 Doors Down - Away From the Sun (CD, Universal Music, 2002)
[A]pply, More candidates, Set url, sKip?
```

This looks more like the import confirmation prompt and shows the URL of the match, which is important for those who want to manually confirm it.
