### PR TITLE
Split level into two separate `classes` and `depth` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ genres. There is also a [tree][rym-tree] of genres and you can set only the most
 specific genres for an album or the union of ancestor genres for each genre. The
 default configuration is setting all primary and secondary genres and their
 ancestors. You can override both settings by using the `classes` and `depth`
-configuration values. The `classes` configuration canbe either `primary` or
-`all`, while `depth` can be either `leaf` or `all`:
+configuration values. The `classes` configuration can be either `primary` or
+`all`, while `depth` can be either `node` or `all`:
 
 ```
 rymgenre:

--- a/beetsplug/rymgenre/__init__.py
+++ b/beetsplug/rymgenre/__init__.py
@@ -110,7 +110,7 @@ class RymGenrePlugin(BeetsPlugin):
         secondary_genres = release_page.xpath('//span[@class="release_sec_genres"]//a[@class="genre"]/text()')
 
         classes = self.config['classes'].as_choice(('primary', 'all'))
-        depth = self.config['depth'].as_choice(('leaf', 'all'))
+        depth = self.config['depth'].as_choice(('node', 'all'))
 
         genres = set(primary_genres)
         if classes == 'all':


### PR DESCRIPTION
This pull request splits the `level` option in two options: `classes` and `depth`. The first one controls what "leaf" genres should we consider: only primary genres or all of them (and possibly other future options, such as choosing the most voted genre *wink*). The `depth` option can be used to control the "specificness" of the genres to be set: only the most specific ones or all ancestors. Likewise, there can be new options in the future, such as reducing all genres to a certain height in the tree (e.g. if one wants to set only top-level or depth 2 genres).

Feel free to rename the config keys and values and modify the README of this PR, I'm not sure they're the best ones.
